### PR TITLE
Avoid remote font fetch and guard Firebase init

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,10 @@
 
 html, body { min-height: 100%; }
 
+.font-cinzel {
+  font-family: "Cinzel", serif;
+}
+
 .bg-dots {
   background-image: radial-gradient(currentColor 0.6px, transparent 0.6px);
   background-size: 12px 12px;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,8 @@
 import "./globals.css";
 import ThemeInit from "@/components/ThemeInit";
-import { Cinzel } from "next/font/google";
-
-const cinzel = Cinzel({ subsets: ["latin"], weight: ["700", "800", "900"] });
+import "@fontsource/cinzel/700.css";
+import "@fontsource/cinzel/800.css";
+import "@fontsource/cinzel/900.css";
 
 export const metadata = {
   title: "Инквизиция — Активность альянса",
@@ -27,7 +27,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
         {/* Заголовок */}
         <header className="w-full flex justify-center pt-6 md:pt-8 pb-2 md:pb-4">
-          <h1 className={`${cinzel.className} text-4xl md:text-5xl font-extrabold text-yellow-300 drop-shadow-[0_3px_8px_rgba(0,0,0,0.45)]`}>
+          <h1 className="font-cinzel text-4xl md:text-5xl font-extrabold text-yellow-300 drop-shadow-[0_3px_8px_rgba(0,0,0,0.45)]">
             Инквизиция
           </h1>
         </header>

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -2,16 +2,29 @@ import { initializeApp, getApps } from "firebase/app";
 import { getAuth, GoogleAuthProvider } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
-};
+let auth: ReturnType<typeof getAuth>;
+let provider: GoogleAuthProvider;
+let db: ReturnType<typeof getFirestore>;
 
-const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+if (typeof window !== "undefined") {
+  const firebaseConfig = {
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
+  };
 
-export const auth = getAuth(app);
-export const provider = new GoogleAuthProvider();
-export const db = getFirestore(app);
+  const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+
+  auth = getAuth(app);
+  provider = new GoogleAuthProvider();
+  db = getFirestore(app);
+} else {
+  // Provide empty objects during server-side build to avoid Firebase initialization
+  auth = {} as ReturnType<typeof getAuth>;
+  provider = {} as GoogleAuthProvider;
+  db = {} as ReturnType<typeof getFirestore>;
+}
+
+export { auth, provider, db };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ants-alliance",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/cinzel": "^5.2.6",
         "clsx": "^2.1.1",
         "firebase": "^12.1.0",
         "next": "15.4.6",
@@ -835,6 +836,15 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.4.tgz",
       "integrity": "sha512-6m8+P+dE/RPl4OPzjTxcTbQ0rGeRyeTvAi9KwIffBVCiAMKrfXfLZaqD1F+m8t4B5/Q5aHsMozOgirkH1F5oMQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@fontsource/cinzel": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/cinzel/-/cinzel-5.2.6.tgz",
+      "integrity": "sha512-ec+bdUJiEugRaDxoXAt7GWb0dYiAW6256a4OsZ8UXgAdsxF798xa9l/B/WrgHTExFhWYWNB0Y9xqcfbqWajTAw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.15",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fontsource/cinzel": "^5.2.6",
     "clsx": "^2.1.1",
     "firebase": "^12.1.0",
     "next": "15.4.6",


### PR DESCRIPTION
## Summary
- load Cinzel font locally via `@fontsource`
- avoid Firebase initialization during server build to prevent invalid API key errors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68998dac7b74832a9535be9d9a247878