### PR TITLE
Remove duplicate language toggle and shrink header button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,6 @@ import PlayersTable from "@/components/PlayersTable";
 import SummaryCard from "@/components/SummaryCard";
 import useSummary from "@/lib/useSummary";
 import ThemeToggle from "@/components/ThemeToggle";
-import LanguageToggle from "@/components/LanguageToggle";
 import { useLang } from "@/components/LanguageProvider";
 
 export default function Page() {
@@ -90,7 +89,6 @@ export default function Page() {
         <h1 className="text-xl md:text-2xl font-bold text-white">{t.allianceActivity}</h1>
         <div className="flex items-center gap-2">
           <ThemeToggle />
-          <LanguageToggle />
           <span className="text-sm opacity-70">{user.email}</span>
           <button onClick={signOutNow} className="rounded-xl px-3 py-2 bg-slate-200 dark:bg-slate-700 dark:text-white hover:bg-slate-300 dark:hover:bg-slate-600">{t.signOut}</button>
         </div>

--- a/components/LanguageToggle.tsx
+++ b/components/LanguageToggle.tsx
@@ -6,7 +6,7 @@ export default function LanguageToggle() {
   return (
     <button
       onClick={toggle}
-      className="rounded-xl px-3 py-2 border bg-white dark:bg-slate-800 dark:text-white dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-700"
+      className="rounded-lg px-2 py-1 text-sm border bg-white dark:bg-slate-800 dark:text-white dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-700"
       title={t.changeLanguage}
     >
       {lang === "ru" ? "EN" : "RU"}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -9,7 +9,7 @@ export default function SiteHeader() {
       <h1 className="font-cinzel text-4xl md:text-5xl font-extrabold text-yellow-300 drop-shadow-[0_3px_8px_rgba(0,0,0,0.45)]">
         {t.siteTitle}
       </h1>
-      <div className="absolute right-4 top-4">
+      <div className="absolute right-2 top-2">
         <LanguageToggle />
       </div>
     </header>


### PR DESCRIPTION
## Summary
- remove extra language switch from page header
- resize and reposition language button in site header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899caebd1c0832a9c01a0a3673fc89e