### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/components/PlayersTable.tsx
+++ b/components/PlayersTable.tsx
@@ -26,118 +26,193 @@ export default function PlayersTable({
   const totalAll = players.reduce((a, p) => a + Number(p.allTime || 0), 0);
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead className="bg-slate-100 dark:bg-slate-700 dark:text-white">
-          <tr>
-            <th className="p-2 text-left">{t.player}</th>
-            {dayNames.map((d) => (
-              <th key={d} className="p-2">
-                {d}
-              </th>
+    <div>
+      {/* Версия для больших экранов — таблица */}
+      <div className="hidden md:block overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-100 dark:bg-slate-700 dark:text-white">
+            <tr>
+              <th className="p-2 text-left">{t.player}</th>
+              {dayNames.map((d) => (
+                <th key={d} className="p-2">
+                  {d}
+                </th>
+              ))}
+              <th className="p-2">{t.weekTotal}</th>
+              <th className="p-2">{t.allTotal}</th>
+              <th className="p-2 text-left">{t.note}</th>
+              <th className="p-2">{t.actions}</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            {players.map((p) => (
+              <tr
+                key={p.id}
+                className="border-t dark:border-slate-700 transition hover:border-yellow-400 hover:shadow-[0_0_6px_rgba(255,215,0,0.35)]"
+              >
+                {/* Имя */}
+                <td className="p-2">
+                  <input
+                    key={`name-${p.id}-${p.name}`}
+                    defaultValue={p.name}
+                    onBlur={(e) => onNameBlur(p, e.currentTarget.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+                    }}
+                    className="w-full rounded-lg border px-2 py-1 bg-white dark:bg-slate-800 dark:text-white dark:border-slate-700 focus:outline-none focus:ring focus:ring-emerald-200"
+                  />
+                </td>
+
+                {/* Дни недели */}
+                {dayKeys.map((k) => (
+                  <td key={k} className="p-2 text-center">
+                    <input
+                      type="checkbox"
+                      checked={!!p.week[k]}
+                      onChange={() => onToggle(p, k)}
+                      className="h-5 w-5 accent-emerald-600"
+                    />
+                  </td>
+                ))}
+
+                {/* Итого за неделю — прогресс 0..7 */}
+                <td className="p-2">
+                  <div className="h-6 rounded-md bg-emerald-100 dark:bg-emerald-900/30 relative overflow-hidden">
+                    <div
+                      className="absolute inset-y-0 left-0 bg-emerald-500 dark:bg-emerald-400 transition-all"
+                      style={{ width: `${((p.weekTotal || 0) / 7) * 100}%` }}
+                    />
+                    <div className="absolute inset-0 flex items-center justify-center text-[12px] font-semibold text-slate-900 dark:text-white">
+                      {p.weekTotal || 0}
+                    </div>
+                  </div>
+                </td>
+
+                {/* Всего — центр. число или «горящая» звезда с числом внутри у лидера */}
+                <td className="p-2 text-center">
+                  {Number(p.allTime || 0) === maxAll && maxAll > 0 ? (
+                    <StarBadge value={Number(p.allTime || 0)} />
+                  ) : (
+                    <span className="text-white">{p.allTime ?? 0}</span>
+                  )}
+                </td>
+
+                {/* Заметка */}
+                <td className="p-2">
+                  <input
+                    key={`note-${p.id}-${p.note ?? ""}`}
+                    defaultValue={p.note ?? ""}
+                    placeholder={t.notePlaceholder}
+                    onBlur={(e) => onNoteBlur(p, e.currentTarget.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+                    }}
+                    className="w-full rounded-lg border px-2 py-1 bg-white dark:bg-slate-800 dark:text-white dark:border-slate-700 focus:outline-none focus:ring focus:ring-emerald-200"
+                  />
+                </td>
+
+                {/* Действия */}
+                <td className="p-2 text-center">
+                  <button
+                    onClick={() => onDelete(p)}
+                    className="rounded-lg px-2 py-1 bg-rose-600 text-white hover:bg-rose-700"
+                  >
+                    {t.delete}
+                  </button>
+                </td>
+              </tr>
             ))}
-            <th className="p-2">{t.weekTotal}</th>
-            <th className="p-2">{t.allTotal}</th>
-            <th className="p-2 text-left">{t.note}</th>
-            <th className="p-2">{t.actions}</th>
-          </tr>
-        </thead>
 
-        <tbody>
-          {players.map((p) => (
-            <tr
-              key={p.id}
-              className="border-t dark:border-slate-700 transition hover:border-yellow-400 hover:shadow-[0_0_6px_rgba(255,215,0,0.35)]"
-            >
-              {/* Имя */}
-              <td className="p-2">
-                <input
-                  key={`name-${p.id}-${p.name}`}
-                  defaultValue={p.name}
-                  onBlur={(e) => onNameBlur(p, e.currentTarget.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") (e.target as HTMLInputElement).blur();
-                  }}
-                  className="w-full rounded-lg border px-2 py-1 bg-white dark:bg-slate-800 dark:text-white dark:border-slate-700 focus:outline-none focus:ring focus:ring-emerald-200"
-                />
+            {/* Строка ИТОГО — центр и белый текст */}
+            <tr className="bg-slate-800">
+              <td colSpan={12} className="p-3 text-center text-white font-bold">
+                {t.totalRow.replace('{week}', String(totalWeek)).replace('{all}', String(totalAll))}
               </td>
+            </tr>
 
-              {/* Дни недели */}
-              {dayKeys.map((k) => (
-                <td key={k} className="p-2 text-center">
+            {players.length === 0 && (
+              <tr>
+                <td colSpan={12} className="p-6 text-center text-slate-500 dark:text-slate-300">
+                  {t.noPlayers}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Версия для мобильных — карточки */}
+      <div className="md:hidden space-y-4">
+        {players.map((p) => (
+          <div
+            key={p.id}
+            className="rounded-lg border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-800"
+          >
+            <input
+              key={`m-name-${p.id}-${p.name}`}
+              defaultValue={p.name}
+              onBlur={(e) => onNameBlur(p, e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+              }}
+              className="w-full rounded-lg border px-2 py-1 mb-2 bg-white dark:bg-slate-800 dark:text-white dark:border-slate-700 focus:outline-none focus:ring focus:ring-emerald-200"
+            />
+            <div className="flex justify-between mb-2">
+              {dayKeys.map((k, i) => (
+                <label key={k} className="flex flex-col items-center text-xs">
+                  {dayNames[i]}
                   <input
                     type="checkbox"
                     checked={!!p.week[k]}
                     onChange={() => onToggle(p, k)}
-                    className="h-5 w-5 accent-emerald-600"
+                    className="mt-1 h-5 w-5 accent-emerald-600"
                   />
-                </td>
+                </label>
               ))}
-
-              {/* Итого за неделю — прогресс 0..7 */}
-              <td className="p-2">
-                <div className="h-6 rounded-md bg-emerald-100 dark:bg-emerald-900/30 relative overflow-hidden">
-                  <div
-                    className="absolute inset-y-0 left-0 bg-emerald-500 dark:bg-emerald-400 transition-all"
-                    style={{ width: `${((p.weekTotal || 0) / 7) * 100}%` }}
-                  />
-                  <div className="absolute inset-0 flex items-center justify-center text-[12px] font-semibold text-slate-900 dark:text-white">
-                    {p.weekTotal || 0}
-                  </div>
-                </div>
-              </td>
-
-              {/* Всего — центр. число или «горящая» звезда с числом внутри у лидера */}
-              <td className="p-2 text-center">
+            </div>
+            <div className="flex justify-between text-xs mb-2">
+              <span>
+                {t.weekTotal}: {p.weekTotal || 0}
+              </span>
+              <span className="flex items-center gap-1">
+                {t.allTotal}:{" "}
                 {Number(p.allTime || 0) === maxAll && maxAll > 0 ? (
                   <StarBadge value={Number(p.allTime || 0)} />
                 ) : (
                   <span className="text-white">{p.allTime ?? 0}</span>
                 )}
-              </td>
-
-              {/* Заметка */}
-              <td className="p-2">
-                <input
-                  key={`note-${p.id}-${p.note ?? ""}`}
-                  defaultValue={p.note ?? ""}
-                  placeholder={t.notePlaceholder}
-                  onBlur={(e) => onNoteBlur(p, e.currentTarget.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") (e.target as HTMLInputElement).blur();
-                  }}
-                  className="w-full rounded-lg border px-2 py-1 bg-white dark:bg-slate-800 dark:text-white dark:border-slate-700 focus:outline-none focus:ring focus:ring-emerald-200"
-                />
-              </td>
-
-              {/* Действия */}
-              <td className="p-2 text-center">
-                <button
-                  onClick={() => onDelete(p)}
-                  className="rounded-lg px-2 py-1 bg-rose-600 text-white hover:bg-rose-700"
-                >
-                  {t.delete}
-                </button>
-              </td>
-            </tr>
-          ))}
-
-          {/* Строка ИТОГО — центр и белый текст */}
-          <tr className="bg-slate-800">
-            <td colSpan={12} className="p-3 text-center text-white font-bold">
-              {t.totalRow.replace('{week}', String(totalWeek)).replace('{all}', String(totalAll))}
-            </td>
-          </tr>
-
-          {players.length === 0 && (
-            <tr>
-              <td colSpan={12} className="p-6 text-center text-slate-500 dark:text-slate-300">
-                {t.noPlayers}
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
+              </span>
+            </div>
+            <input
+              key={`m-note-${p.id}-${p.note ?? ""}`}
+              defaultValue={p.note ?? ""}
+              placeholder={t.notePlaceholder}
+              onBlur={(e) => onNoteBlur(p, e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+              }}
+              className="w-full rounded-lg border px-2 py-1 mb-2 bg-white dark:bg-slate-800 dark:text-white dark:border-slate-700 focus:outline-none focus:ring focus:ring-emerald-200"
+            />
+            <div className="text-right">
+              <button
+                onClick={() => onDelete(p)}
+                className="rounded-lg px-2 py-1 bg-rose-600 text-white hover:bg-rose-700"
+              >
+                {t.delete}
+              </button>
+            </div>
+          </div>
+        ))}
+        {players.length === 0 && (
+          <div className="p-6 text-center text-slate-500 dark:text-slate-300">{t.noPlayers}</div>
+        )}
+        {players.length > 0 && (
+          <div className="p-3 text-center text-white font-bold bg-slate-800 rounded-lg">
+            {t.totalRow.replace('{week}', String(totalWeek)).replace('{all}', String(totalAll))}
+          </div>
+        )}
+      </div>
 
       {/* Глобальные ключевые кадры для «горящей» звезды */}
       <style jsx global>{`

--- a/components/SummaryCard.tsx
+++ b/components/SummaryCard.tsx
@@ -10,13 +10,13 @@ export default function SummaryCard({ summary }: { summary: SummaryMap }) {
   const totalAll  = rows.reduce((a, b) => a + (b.all  || 0), 0);
 
   return (
-    <div className="relative rounded-2xl">
+    <div className="relative rounded-2xl overflow-hidden">
       {/* ДВА ОСКОЛКА — рисуем абсолютными слоями, чтобы всегда иметь высоту */}
-      {/* Левый осколок (30%) */}
+      {/* Левый осколок */}
       <div
         aria-hidden
         className="
-          pointer-events-none absolute inset-y-0 left-0 w-[30%] z-0
+          pointer-events-none absolute inset-y-0 left-0 w-1/2 sm:w-[30%] z-0
           bg-gradient-to-br from-slate-950 via-slate-900 to-blue-950
           backdrop-blur-md shadow-[inset_0_0_40px_rgba(255,255,255,0.08)]
           rounded-l-2xl
@@ -39,11 +39,11 @@ export default function SummaryCard({ summary }: { summary: SummaryMap }) {
           `,
         }}
       />
-      {/* Правый осколок (30%) */}
+      {/* Правый осколок */}
       <div
         aria-hidden
         className="
-          pointer-events-none absolute inset-y-0 right-0 w-[30%] z-0
+          pointer-events-none absolute inset-y-0 right-0 w-1/2 sm:w-[30%] z-0
           bg-gradient-to-bl from-slate-950 via-slate-900 to-blue-950
           backdrop-blur-md shadow-[inset_0_0_40px_rgba(255,255,255,0.08)]
           rounded-r-2xl
@@ -67,11 +67,11 @@ export default function SummaryCard({ summary }: { summary: SummaryMap }) {
         }}
       />
 
-      {/* КОНТЕНТ — поверх стекла. Сетка 30% / 40% / 30% сохраняет разрыв по центру */}
-      <div className="relative z-10 grid grid-cols-[30%_40%_30%] gap-y-2 px-4 py-3 text-white">
+      {/* КОНТЕНТ — поверх стекла. На мобильных 2 колонки 50/50, на больших 30/40/30 */}
+      <div className="relative z-10 grid grid-cols-2 sm:grid-cols-[30%_40%_30%] gap-y-2 px-4 py-3 text-white">
         {/* Заголовок */}
         <div className="col-start-1 font-semibold">{t.summary}</div>
-        <div className="col-start-3" />
+        <div className="col-start-2 sm:col-start-3" />
 
         {/* Строки: слева название роли, справа цифры */}
         {rows.map((r) => (
@@ -79,7 +79,10 @@ export default function SummaryCard({ summary }: { summary: SummaryMap }) {
             <div key={`${r.role}-l`} className="col-start-1 text-sm font-medium">
               {roleLabel(r.role, lang)}
             </div>
-            <div key={`${r.role}-r`} className="col-start-3 text-sm tabular-nums text-right">
+            <div
+              key={`${r.role}-r`}
+              className="col-start-2 sm:col-start-3 text-sm tabular-nums text-right"
+            >
               {r.count ?? 0} | {t.week}: {r.week ?? 0} | {t.all}: {r.all ?? 0}
             </div>
           </>
@@ -87,7 +90,7 @@ export default function SummaryCard({ summary }: { summary: SummaryMap }) {
 
         {/* ИТОГО — слово слева, суммы справа */}
         <div className="col-start-1 text-sm font-semibold">{t.total}</div>
-        <div className="col-start-3 text-sm font-semibold tabular-nums text-right">
+        <div className="col-start-2 sm:col-start-3 text-sm font-semibold tabular-nums text-right">
           {t.week}: {totalWeek} | {t.all}: {totalAll}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- adjust summary card layout for mobile by resizing shards and grid
- add mobile card view for players table with player name above weekly checkboxes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899d3518478832abcc9d20d4407ef98